### PR TITLE
Handle missing version file in version bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,15 @@ java {
     targetCompatibility = JavaVersion.VERSION_11
 }
 
-groovy {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+sourceSets {
+    test {
+        groovy.srcDirs = ['test']
+    }
+}
+
+tasks.withType(org.gradle.api.tasks.compile.GroovyCompile).configureEach {
+    sourceCompatibility = JavaVersion.VERSION_11.toString()
+    targetCompatibility = JavaVersion.VERSION_11.toString()
 }
 
 test {

--- a/src/com/company/jenkins/PythonSteps.groovy
+++ b/src/com/company/jenkins/PythonSteps.groovy
@@ -137,8 +137,20 @@ print(str(new))
         """
         
         // Store the new version in environment for later use
+        // Read the new version from the appropriate source file
+        def versionReadCmd = """
+            source venv/bin/activate
+            if [ -f "${config.versionFile}" ]; then
+                cat ${config.versionFile}
+            elif [ -f "${config.setupFile}" ]; then
+                python -c "import re; print(re.search(r'version=[\"\']([^\"\']+)[\"\']', open('${config.setupFile}').read()).group(1))"
+            else
+                echo ""
+            fi
+        """
+
         script.env.NEW_VERSION = script.sh(
-            script: "source venv/bin/activate && cat ${config.versionFile}",
+            script: versionReadCmd,
             returnStdout: true
         ).trim()
         


### PR DESCRIPTION
## Summary
- read bumped version from version file or setup.py
- configure Gradle to compile Groovy sources and include test directory
- expand unit tests for version bump behavior

## Testing
- `gradle test` *(fails: Could not resolve all files for configuration ':testCompileClasspath' - received status code 403 from repositories)*

------
https://chatgpt.com/codex/tasks/task_e_6893da34757c832e85ca2e45b6eaf8ad